### PR TITLE
Fix setting keys and the settings schema

### DIFF
--- a/LSP-terraform.sublime-settings
+++ b/LSP-terraform.sublime-settings
@@ -6,11 +6,15 @@
   ],
   "selector": "source.terraform",
   "initializationOptions": {
-    // Per-workspace list of module directories for the language server to exclude
-    "terraform-ls.excludeRootModules": [],
-    // Experimental (opt-in) terraform-ls features
-    "terraform-ls.experimentalFeatures": {},
-    // Per-workspace list of module directories for the language server to read
-    "terraform-ls.rootModules": [],
+    // Overrides automatic root module discovery by passing a static list of
+    // absolute or relative paths to root modules.
+    // Conflicts with `excludeModulePaths` option.
+    "rootModulePaths": [],
+    // Excludes root module path when automatic root module discovery by passing
+    // a static list of absolute or relative paths to root modules.
+    // Conflicts with `rootModulePaths` option.
+    "excludeModulePaths": [],
+    // Runs terraform validate within the folder of the file saved.
+    "experimentalFeatures.validateOnSave": false,
   }
 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -14,31 +14,26 @@
                                     "additionalProperties": false,
                                     "type": "object",
                                     "properties": {
-                                        "terraform-ls.excludeRootModules": {
+                                        "rootModulePaths": {
                                             "default": [],
-                                            "description": "Per-workspace list of module directories for the language server to exclude",
+                                            "markdownDescription": "This allows overriding automatic root module discovery by passing a static list of absolute or relative paths to root modules (i.e. folders with `*.tf` files which have been `terraform init`-ed). Conflicts with `excludeModulePaths` option.\n\nRelative paths are resolved relative to the directory opened in the editor.\n\nPath separators are converted automatically to the match separators of the target platform (e.g. `\\` on Windows, or `/` on Unix), symlinks are followed, trailing slashes automatically removed, and `~` is replaced with your home directory.",
                                             "items": {
                                                 "type": "string"
                                             },
                                             "type": "array"
                                         },
-                                        "terraform-ls.experimentalFeatures": {
-                                            "description": "Experimental (opt-in) terraform-ls features",
-                                            "properties": {
-                                                "validateOnSave": {
-                                                    "default": false,
-                                                    "type": "boolean"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "terraform-ls.rootModules": {
+                                        "excludeModulePaths": {
                                             "default": [],
-                                            "description": "Per-workspace list of module directories for the language server to read",
+                                            "markdownDescription": "This allows exclude root module path when automatic root module discovery by passing a static list of absolute or relative paths to root modules (i.e. folders with `*.tf` files which have been `terraform init`-ed). Conflicts with `rootModulePaths` option.\n\n Relative paths are resolved relative to the directory opened in the editor.\n\n Path separators are converted automatically to the match separators of the target platform (e.g. `\\` on Windows, or `/` on Unix), symlinks are followed, trailing slashes automatically removed, and `~` is replaced with your home directory.",
                                             "items": {
                                                 "type": "string"
                                             },
                                             "type": "array"
+                                        },
+                                        "experimentalFeatures.validateOnSave": {
+                                            "markdownDescription": "Enabling this feature will run terraform validate within the folder of the file saved. This comes with some user experience caveats.\n\n- Validation is not run on file open, only once it's saved.\n- When editing a module file, validation is not run due to not knowing which \"rootmodule\" to run validation from (there could be multiple). This creates an awkward workflow where when saving a file in a rootmodule, a diagnostic is raised in a module file. Editing the module file will not clear the diagnostic for the reason mentioned above, it will only clear once a file is saved back in the original \"rootmodule\".",
+                                            "default": false,
+                                            "type": "boolean"
                                         },
                                     }
                                 },


### PR DESCRIPTION
Getting the schema directly from the VSCode extension is not guaranteed to work as the extension settings don't necessarily map 1:1 to the server settings. In this case the server itself has good documentation of its settings so that can be used instead. In other cases, studying the extension code might be necessary to figure out what applies to the plain server.